### PR TITLE
add commands to force integer indexing, close #3

### DIFF
--- a/focusCoords.m
+++ b/focusCoords.m
@@ -11,5 +11,5 @@ dd = dd-min(dd);
 
 icmat = zeros(size(coords,1),length(icvec));
 for i=1:size(coords,1)
-  icmat(i,dd(i)+1:end)  = icvec(1:end-dd(i));
+  icmat(i,ceil(dd(i))+1:end)  = icvec(1:end-ceil(dd(i)));
 end


### PR DESCRIPTION
Please verify that this does not produce any off-by-one errors.
It may be worth looking at `ceil`, `floor`, `round`, and `fix` (note they may behave differently for positive and negative numbers).